### PR TITLE
HOTFIX - Use https to download assets from drupal.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "name": "drupalmodule/coder",
         "version": "7.2.5",
         "dist": {
-          "url": "http://ftp.drupal.org/files/projects/coder-7.x-2.5.zip",
+          "url": "https://ftp.drupal.org/files/projects/coder-7.x-2.5.zip",
           "type": "zip"
         }
       }


### PR DESCRIPTION
Drupal made some improvements to their asset servers recently (YAY, because everything should be https). This breaks aquifer-coder, because it was trying to use http to grab assets.
## Steps to test
- Checkout this branch (clone this repo first)
- If previously installed, remove all vendor directories.
- Run `npm install`
- Ensure all dependencies are downloaded correctly.
