### PR TITLE
Updates and enhancements for 1.0.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 env:
     node: true
+    es6: true
 
 rules:
     indent: [2, 2, {VariableDeclarator: 2}]

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This extension adds a few commands to the Aquifer CLI within your project:
 Running any of these commands will create a report that outlines any coding standards violations or linting errors in your codebase. A default set of eslint rules is provided, and the Drupal Coding Standards PHPCodesniffer rules are used.
 
 ## Configuration
-You might not want to use the eslint rules provided with this extension, or the Drupal Coding Standards. This extension provides two optional parameters:
+You might not want to use the eslint rules, Drupal Coding Standards, or other default configurations defined by this extension. In such cases, you can override the defaults using these examples:
 
 _in your `aquifer.json` file:_
 ```javascript
@@ -26,9 +26,24 @@ _in your `aquifer.json` file:_
 "extensions": {
   "aquifer-coder": {
     "source": "aquifer-coder",
-    "eslintrc": "relative/path/to/.eslintrc",
-    "eslintIgnore": "relative/path/to/.eslintignore"
-    "phpcsStandard": "relative/path/to/phpcsStandardFile"
+    "eslint": {
+      "config": "relative/path/to/.eslintrc",
+      "ignore": "relative/path/to/.eslintignore"
+      "targets": [
+        "modules/custom",
+        "themes/custom",
+        "*.js"
+      ]
+    },
+    "phpcs": {
+      "config": "relative/path/to/phpcsStandardFile"
+      "ignore": "*.views_default.inc,*.context.inc"
+      "targets": [
+        "modules/custom",
+        "themes/custom"
+      ],
+      extensions: "php,module,inc,install,test,profile,theme"
+    }
   }
 }
 ...

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ _in your `aquifer.json` file:_
         "modules/custom",
         "themes/custom"
       ],
-      extensions: "php,module,inc,install,test,profile,theme"
+      "extensions": "php,module,inc,install,test,profile,theme"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -26,23 +26,25 @@ _in your `aquifer.json` file:_
 "extensions": {
   "aquifer-coder": {
     "source": "aquifer-coder",
-    "eslint": {
-      "config": "relative/path/to/.eslintrc",
-      "ignore": "relative/path/to/.eslintignore"
-      "targets": [
-        "modules/custom",
-        "themes/custom",
-        "*.js"
-      ]
-    },
-    "phpcs": {
-      "config": "relative/path/to/phpcsStandardFile"
-      "ignore": "*.views_default.inc,*.context.inc"
-      "targets": [
-        "modules/custom",
-        "themes/custom"
-      ],
-      "extensions": "php,module,inc,install,test,profile,theme"
+    "config": {
+      "eslint": {
+        "config": "relative/path/to/.eslintrc",
+        "ignore": "relative/path/to/.eslintignore"
+        "targets": [
+          "modules/custom",
+          "themes/custom",
+          "*.js"
+        ]
+      },
+      "phpcs": {
+        "config": "relative/path/to/phpcsStandardFile"
+        "ignore": "*.views_default.inc,*.context.inc"
+        "targets": [
+          "modules/custom",
+          "themes/custom"
+        ],
+        "extensions": "php,module,inc,install,test,profile,theme"
+      }
     }
   }
 }

--- a/aquifer-coder.js
+++ b/aquifer-coder.js
@@ -22,8 +22,8 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
 
   // Turn any passed-in paths into full paths.
   if (AquiferCoderConfig.hasOwnProperty('eslint')) {
-    if (AquiferCoderConfig.hasOwnProperty('standard')) {
-      AquiferCoderConfig.eslint.standard = path.join(Aquifer.projectDir, AquiferCoderConfig.eslint.standard);
+    if (AquiferCoderConfig.hasOwnProperty('config')) {
+      AquiferCoderConfig.eslint.config = path.join(Aquifer.projectDir, AquiferCoderConfig.eslint.config);
     }
 
     if (AquiferCoderConfig.hasOwnProperty('ignore')) {
@@ -32,8 +32,8 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
   }
 
   if (AquiferCoderConfig.hasOwnProperty('phpcs')) {
-    if (AquiferCoderConfig.hasOwnProperty('standard')) {
-      AquiferCoderConfig.phpcs.standard = path.join(Aquifer.projectDir, AquiferCoderConfig.phpcs.standard);
+    if (AquiferCoderConfig.hasOwnProperty('config')) {
+      AquiferCoderConfig.phpcs.config = path.join(Aquifer.projectDir, AquiferCoderConfig.phpcs.config);
     }
   }
 

--- a/aquifer-coder.js
+++ b/aquifer-coder.js
@@ -50,7 +50,7 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
     },
     phpcs: {
       config: path.join(__dirname, '/vendor/drupalmodule/coder/coder_sniffer/Drupal'),
-      ignore: "*.apachesolr_environments.inc,*.apachesolr_search_defaults.inc,*.context.inc,*.features.*.inc,*.features.inc,*.field_group.inc,*.pages_default.inc,*.strongarm.inc,*.views_default.inc",
+      ignore: '*.apachesolr_environments.inc,*.apachesolr_search_defaults.inc,*.context.inc,*.features.*.inc,*.features.inc,*.field_group.inc,*.pages_default.inc,*.strongarm.inc,*.views_default.inc',
       targets: [
         'modules/custom',
         'themes/custom'
@@ -190,6 +190,7 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
 
   /**
    * Run eslint on custom files in project.
+   * @param {Object[]} targets an array of target paths to lint.
    * @returns {undefined} nothing.
    */
   AquiferCoder.eslint = function (targets) {
@@ -235,6 +236,7 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
 
   /**
    * Lints PHP code in codebase.
+   * @param {Object[]} targets an array of target paths to lint.
    * @returns {undefined} nothing.
    */
   AquiferCoder.phplint = function (targets) {
@@ -265,16 +267,17 @@ module.exports = function(Aquifer, AquiferCoderConfig) {
 
   /**
    * Runs phpcs on PHP code in codebase.
+   * @param {Object[]} targets an array of target paths to lint.
    * @returns {undefined} nothing.
    */
   AquiferCoder.phpcs = function (targets) {
     // Define phpcs command and options as an array.
     let command = [
       path.join(__dirname, '/vendor/bin/phpcs'),
-        '--standard="' + AquiferCoderConfig.phpcs.config + '"',
-        '--extensions="' + AquiferCoderConfig.phpcs.extensions + '"',
-        '--ignore="' + AquiferCoderConfig.phpcs.ignore + '"'
-      ];
+      '--standard="' + AquiferCoderConfig.phpcs.config + '"',
+      '--extensions="' + AquiferCoderConfig.phpcs.extensions + '"',
+      '--ignore="' + AquiferCoderConfig.phpcs.ignore + '"'
+    ];
 
     // Add target directories to the command array.
     _.forEach(targets, function(target) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "aquifer-coder.js",
   "dependencies": {
     "colors": "^1.1.2",
-    "eslint": "^1.5.1",
+    "eslint": "^2.13.1",
     "fs-extra": "^0.24.0",
     "jscs": "^2.2.1",
     "lodash": "^3.10.1",


### PR DESCRIPTION
See [this issue](https://github.com/aquifer/aquifer/issues/164) for the Aquifer 1.0.0 release milestone.
- Updates `aquifer-coder` to be compatible with Aquifer `1.0.0` branch.
- Makes configuration options more robust.
- Docs updated for compatibility with: https://github.com/aquifer/aquifer/pull/172

**To test:**
- [x] Load up this branch in your Aquifer project.
- [x] Create a `test` directory in `modules/custom`
- [x] Add a `test.module` and a `test.js` file to the module and populate both with code containing code standards errors for that language.
- [x] Run `aquifer lint` and ensure your errors are caught.
- [x] See the README for new config override format and options and test them to ensure they work as expected.
- [x] Run `aquifer lint -t modules/custom/test/test.js`
  - [x] Verify only the js file is linted
- [x] Run `aquifer lint -t modules/custom/test/test.module`
  - [x] Verify only the module file is linted
